### PR TITLE
Changes to resolve issue #14, #15, and #16

### DIFF
--- a/src/TodoItem.jsx
+++ b/src/TodoItem.jsx
@@ -42,8 +42,8 @@ export function TodoItem({ completed, id, title, description, toggleTodo, delete
                         id="edit-description"
                         data-test="edit-description"
                     />
-                    <button type="submit">Save</button>
-                    <button onClick={handleCancel}>Cancel</button>
+                    <button type="submit" data-test="button-edit-save">Save</button>
+                    <button onClick={handleCancel} data-test="button-edit-cancel">Cancel</button>
                 </form>
                 ) : (
                     <>

--- a/src/TodoList.jsx
+++ b/src/TodoList.jsx
@@ -5,7 +5,7 @@ import { TodoItem } from "./TodoItem"
 export function TodoList({ todos, toggleTodo, deleteTodo, editTodo }) {
   return (
       <ul id="todo-list" data-test="todo-list">
-      { todos.length === 0 && "No Todos"}
+      { todos.length === 0 ? "No Todos" : `Number of TODO items: ${todos.length}`}
       { todos.map(todo => {
         return (
           <TodoItem 

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -33,4 +33,41 @@ test.describe("TODO app", () => {
 
     await expect(page.locator('[data-test="todo-list"]')).toHaveText('No Todos')
   })
+
+  test("Should edit TODO item after clicking save", async ({page}) => {
+    await page.locator('[data-test="item"]').fill('This is the title')
+    await page.locator('[data-test="description"]').fill('This is the description')
+    await page.locator('[data-test="button-add-todo"]').click()
+
+    await expect(page.locator('[data-test="todo-title"]')).toHaveText('This is the title')
+    await expect(page.locator('[data-test="todo-description"]')).toHaveText('This is the description')
+
+    // Update both title and description
+    await page.locator('[data-test="button-edit"]').click()
+    await page.locator('[data-test="edit-item"]').fill('This is the updated title')
+    await page.locator('[data-test="edit-description"]').fill('This is the updated description')
+    await page.locator('[data-test="button-edit-save"]').click()
+    await expect(page.locator('[data-test="todo-title"]')).toHaveText('This is the updated title')
+    await expect(page.locator('[data-test="todo-description"]')).toHaveText('This is the updated description')
+
+    // Update title only
+    await page.locator('[data-test="button-edit"]').click()
+    await page.locator('[data-test="edit-item"]').fill('This is the updated title the second')
+    await page.locator('[data-test="button-edit-save"]').click()
+    await expect(page.locator('[data-test="todo-title"]')).toHaveText('This is the updated title the second')
+    await expect(page.locator('[data-test="todo-description"]')).toHaveText('This is the updated description')
+
+    // Update description only
+    await page.locator('[data-test="button-edit"]').click()
+    await page.locator('[data-test="edit-description"]').fill('This is the updated description the second')
+    await page.locator('[data-test="button-edit-save"]').click()
+    await expect(page.locator('[data-test="todo-title"]')).toHaveText('This is the updated title the second')
+    await expect(page.locator('[data-test="todo-description"]')).toHaveText('This is the updated description the second')
+
+    // Update nothing and click save
+    await page.locator('[data-test="button-edit"]').click()
+    await page.locator('[data-test="button-edit-save"]').click()
+    await expect(page.locator('[data-test="todo-title"]')).toHaveText('This is the updated title the second')
+    await expect(page.locator('[data-test="todo-description"]')).toHaveText('This is the updated description the second')
+  })
 })


### PR DESCRIPTION
This pull request contain the following changes:

In TodoItem.jsx
- added data-test attribute in the save and cancel button

In TodoList.jsx
- added feature to count and display current number of TODO items

In ui.spec.js
- added 1 test that covers that edit functionality

This pull request aims to resolve the following issues:
- #14 
- #15 
- #16 